### PR TITLE
Update base.list.chroot

### DIFF
--- a/config/package-lists/base.list.chroot
+++ b/config/package-lists/base.list.chroot
@@ -20,3 +20,4 @@ git
 numlockx
 nfs-common
 expect
+wget


### PR DESCRIPTION
fixes failure " /root/0510-seb.hook.chroot: 34: /root/0510-seb.hook.chroot: wget: not found"